### PR TITLE
Example work over

### DIFF
--- a/examples/Example-01_Hello/Example-01_Hello.ino
+++ b/examples/Example-01_Hello/Example-01_Hello.ino
@@ -1,133 +1,70 @@
+/*
+  Example-01_Hello.ino
 
-// Example-01_Hello.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written by Kirk Benell @ SparkFun Electronics, March 2022
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  This demo shows the basic setup of the OLED library, generating simple graphics and displaying
+  the results on the target device.
 
-// Example 01 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo shows the basic setup of the OLED library, generating simple graphics and displaying
-// the results on the target device.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+  This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Arduino setup() function.
-//
-// Initialize our device and draw a simple graphic. That's all this example does.
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 void setup()
 {
-    delay(500); // Give display time to power on
-
-    // Serial on!
     Serial.begin(115200);
+    Serial.println("Running OLED example");
 
-    Serial.println("\n\r-----------------------------------");
-
-    Serial.print("Running Example 01 on: ");
-    Serial.println(String(deviceName));
+    Wire.begin();
 
     // Initalize the OLED device and related graphics system
-    if (!myOLED.begin())
+    if (myOLED.begin() == false)
     {
-
-        Serial.println(" - Device Begin Failed");
-        while (1)
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
             ;
     }
-
-    Serial.println("- Begin Success");
+    Serial.println("Begin success");
 
     // Do a simple test - fill a rectangle on the screen and then print hello!
 
-    // fill a rectangle on the screen that has a 4 pixel board
+    // Fill a rectangle on the screen that has a 4 pixel board
     myOLED.rectangleFill(4, 4, myOLED.getWidth() - 8, myOLED.getHeight() - 8);
 
     String hello = "hello"; // our message
 
-    // Lets center our message on the screen. We need to current font.
+    // Let's center our message on the screen. We need the current font.
 
     QwiicFont *pFont = myOLED.getFont();
 
-    // starting x position - width minus string length (font width * number of characters) / 2
+    // Starting x position - width minus string length (font width * number of characters) / 2
     int x0 = (myOLED.getWidth() - pFont->width * hello.length()) / 2;
 
     int y0 = (myOLED.getHeight() - pFont->height) / 2;
@@ -141,10 +78,7 @@ void setup()
     // That's it - HELLO!
 }
 
-// Standard Arduino loop function.
 void loop()
 {
-
-    // All loop does in sleep.
-    delay(1000);
+    delay(1000); // Do nothing
 }

--- a/examples/Example-02_Shapes/Example-02_Shapes.ino
+++ b/examples/Example-02_Shapes/Example-02_Shapes.ino
@@ -1,99 +1,95 @@
+/*
+  Example-01_Hello.ino
 
-// Example-02_Shapes.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written by Kirk Benell @ SparkFun Electronics, March 2022
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 2 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo shows the various methods available for drawing shapes using the OLED library
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+  This demo shows the various methods available for drawing shapes using the OLED library
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 // Global variables - used to stash our screen size
 
 int width;
 int height;
 
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println("Running OLED example");
+
+    Wire.begin();
+
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin() == false)
+    {
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
+            ;
+    }
+    Serial.println("Begin success");
+
+    // save device dims for the test routines
+    width = myOLED.getWidth();
+    height = myOLED.getHeight();
+}
+
+void loop()
+{
+    // Loop over our test functions
+    for (int i = 0; i < 7; i++)
+    {
+        myOLED.erase();
+
+        if (i == 0)
+            lineTest1();
+        else if (i == 1)
+            lineTest2();
+        else if (i == 2)
+            lineTestVertical();
+        else if (i == 3)
+            rectangleTest();
+        else if (i == 4)
+            rectangleTestMove();
+        else if (i == 5)
+            rectangleFillTest();
+        else if (i == 6)
+            circleTest();
+
+        myOLED.display();
+
+        delay(1000);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
-// line_test_1()
+// lineTest1()
 //
 // This test draws a horizontal line on the screen, moving it from the
 // top of the screen to the bottom.
@@ -106,9 +102,8 @@ int height;
 // of the display updates also decreases.  A longer line, results in more data being
 // sent to the display.
 
-void line_test_1(void)
+void lineTest1(void)
 {
-
     int x, y, i;
 
     int mid = width / 2;
@@ -131,15 +126,14 @@ void line_test_1(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// line_test_2()
+// lineTest2()
 //
 // This test draws a series of lines bursting out from the corner of the display.
 //
 // It demostrates the abilty of the library to draw arbitray straight lines.
 
-void line_test_2(void)
+void lineTest2(void)
 {
-
     for (int i = 0; i < width; i += 6)
     {
         myOLED.line(0, 0, i, height - 1);
@@ -155,7 +149,7 @@ void line_test_2(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// line_test_vert()
+// lineTestVertIterative()
 //
 // Draws a series of vertical lines, some horz lines and two diag lines.
 //
@@ -163,9 +157,9 @@ void line_test_2(void)
 // vertical lines functions.
 //
 // Iterator function - called to animate graphic
-void line_test_vert_iter(uint8_t y0, uint8_t y1)
-{
 
+void lineTestVerticalIterative(uint8_t y0, uint8_t y1)
+{
     for (int i = 0; i < width; i += 8)
         myOLED.line(i, y0, i, y1);
 
@@ -180,16 +174,15 @@ void line_test_vert_iter(uint8_t y0, uint8_t y1)
 }
 
 // Entry point for test
-void line_test_vert(void)
+void lineTestVertical(void)
 {
-
     int mid = height / 2;
 
     for (int i = 0; i < height; i += 4)
     {
 
         myOLED.erase();
-        line_test_vert_iter(mid - i / 2, mid + i / 2);
+        lineTestVerticalIterative(mid - i / 2, mid + i / 2);
         myOLED.display();
         delay(10);
     }
@@ -199,20 +192,19 @@ void line_test_vert(void)
 // rect_test()
 //
 // Simple - draw a rectangle test
-void rect_test(void)
-{
 
+void rectangleTest(void)
+{
     myOLED.rectangle(4, 4, width - 8, height - 8);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// rect_test_move()
+// rectangleTestMove()
 //
 // Draws a rectangle, then moves it across the screen
 //
-void rect_test_move(void)
+void rectangleTestMove(void)
 {
-
     float steps = height;
     float xinc = width / steps;
     float yinc = height / steps;
@@ -222,7 +214,6 @@ void rect_test_move(void)
 
     for (int i = 0; i < steps; i++)
     {
-
         // Draw the rectangle and send it to device
         myOLED.rectangle(x, y, side, side);
         myOLED.display(); // sends erased rect and new rect pixels to device
@@ -236,14 +227,13 @@ void rect_test_move(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// rect_fill_test()
+// rectangleFillTest()
 //
 // Draws two filled rectangles, switches to XOR draw mode and overwrites them
 // with another rectangle
 
-void rect_fill_test(void)
+void rectangleFillTest(void)
 {
-
     myOLED.rectangleFill(4, 4, width / 2 - 8, height - 8);
 
     myOLED.rectangleFill(width / 2 + 4, 4, width / 2 - 8, height - 8);
@@ -254,13 +244,12 @@ void rect_fill_test(void)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// circle_test()
+// circleTest()
 //
 // Draw a series of circles - filled and not filled
-void circle_test(void)
+void circleTest(void)
 {
-
-    // Lets draw some circles that fit on the device
+    // Let's draw some circles that fit on the device
     myOLED.circle(width / 4, height / 2, height / 3);
 
     myOLED.circleFill(width - width / 4, height / 2, height / 3);
@@ -268,72 +257,4 @@ void circle_test(void)
     myOLED.circle(4, height / 2, height / 3);
 
     myOLED.circleFill(width - width / 2, height / 2, height / 4);
-}
-
-// Make an array of function pointers - used to hold the list of tests to run.
-//
-// Makes the loop call to each test function simple.
-//
-// testing function table
-typedef void (*testFn)(void);
-
-static const testFn testFunctions[] = {
-    line_test_1,
-    line_test_2,
-    line_test_vert,
-    rect_test,
-    rect_test_move,
-    rect_fill_test,
-    circle_test};
-
-////////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Standard Arduino setup routine
-
-void setup()
-{
-    delay(500); // Give display time to power on
-    Serial.begin(115200);
-
-    Serial.println("\n\r-----------------------------------");
-
-    Serial.print("Running Test #2 on: ");
-    Serial.println(String(deviceName));
-
-    if (!myOLED.begin())
-    {
-
-        Serial.println("- Device Begin Failed");
-        while (1)
-            ;
-    }
-
-    Serial.println("- Begin Successful");
-
-    // save device dims for the test routines
-    width = myOLED.getWidth();
-    height = myOLED.getHeight();
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////
-// loop()
-//
-// Standard Arduino loop function.
-
-void loop()
-{
-
-    // Just loop over our test functions
-    for (uint8_t i = 0; i < sizeof(testFunctions) / sizeof(testFunctions[0]); i++)
-    {
-
-        myOLED.erase();
-
-        testFunctions[i](); // next function
-
-        myOLED.display();
-
-        delay(1000);
-    }
 }

--- a/examples/Example-03_Bitmap/Example-03_Bitmap.ino
+++ b/examples/Example-03_Bitmap/Example-03_Bitmap.ino
@@ -1,92 +1,38 @@
+/*
+  Example-03_Bitmap.ino
 
-// Example-03_Bitmap.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written by Nathan Seidle @ SparkFun Electronics
-// Original Creation Date: November 15, 2020
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 3 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo shows how to write a simple bitmap to an OLED screen
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+  This demo shows how to write a simple bitmap to an OLED screen
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 // Let's draw a truck - use our built in bitmap
 #include "res/qw_bmp_truck.h"
@@ -96,84 +42,48 @@ int width;
 int height;
 
 // For simple frame rate calculations
-uint32_t draw_total_time;
-uint32_t n_draws;
-
-////////////////////////////////////////////////////////////////////////////////////////////////
-//  show_splash()
-//
-// Show SFE spash screen
-
-void show_splash()
-{
-
-  int x0 = (width - QW_BMP_SPARKFUN.width) / 2;
-  if (x0 < 0)
-    x0 = 0;
-
-  int y0 = (height - QW_BMP_SPARKFUN.height) / 2;
-  if (y0 < 0)
-    y0 = 0;
-
-  myOLED.erase();
-  myOLED.bitmap(x0, y0, QW_BMP_SPARKFUN);
-  myOLED.display();
-  delay(2000);
-}
-////////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Standard Arduino setup routine
-
-void setup()
-{
-
-  delay(500); // Give display time to power on
-  Serial.begin(115200);
-
-  Serial.println("\n\r-----------------------------------");
-
-  Serial.print("Running Test #2 on: ");
-  Serial.println(String(deviceName));
-
-  if (!myOLED.begin())
-  {
-
-    Serial.println("- Device Begin Failed");
-    while (1)
-      ;
-  }
-
-  Serial.println("- Begin Successful");
-
-  // save device dims for the test routines
-  width = myOLED.getWidth();
-  height = myOLED.getHeight();
-
-  show_splash();
-
-  draw_total_time = 0;
-  n_draws = 0;
-
-  // set a template for our framerate display
-  Serial.println("- Frame Rate");
-}
+long drawTotalTime = 0;
+int numberOfDraws = 0;
 
 int iconX = 8;
 int iconXChangeAmount = 1;
 int iconY = 8;
 int iconYChangeAmount = 1;
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// loop()
-//
-// Standard Arduino loop routine
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println("Running OLED example");
+
+  Wire.begin();
+  Wire.setClock(400000); // Optional increase I2C to 400kHz
+
+  // Initalize the OLED device and related graphics system
+  if (myOLED.begin() == false)
+  {
+    Serial.println("Device begin failed. Freezing...");
+    while (true)
+      ;
+  }
+  Serial.println("Begin success");
+
+  // save device dims for the test routines
+  width = myOLED.getWidth();
+  height = myOLED.getHeight();
+
+  showSplash();
+
+  drawTotalTime = 0;
+  numberOfDraws = 0;
+
+  // set a template for our framerate display
+  Serial.println("- Frame Rate");
+}
 
 void loop()
 {
-
-  // Calculate draw time...
-  uint32_t milStart = millis();
+  // Calculate draw time
+  long startTime = millis();
 
   myOLED.bitmap(iconX, iconY, QW_BMP_TRUCK);
   myOLED.display();
@@ -194,19 +104,32 @@ void loop()
   if (iconY == 0)
     iconYChangeAmount *= -1; // Change direction
 
-  draw_total_time += millis() - milStart;
-  n_draws++;
+  numberOfDraws++;
+  drawTotalTime += (millis() - startTime);
 
-  // output framerate?
-  if (n_draws % 120 == 0)
+  // Output framerate once every 120 frames
+  if (numberOfDraws % 120 == 0)
   {
+    Serial.print(" Frame rate: ");
+    Serial.println(numberOfDraws / (float)drawTotalTime * 1000.0);
 
-    Serial.println(((float)draw_total_time) / n_draws);
-
-    if (n_draws > 1000)
-    { // reset after a bit...
-      n_draws = 0;
-      draw_total_time = 0;
-    }
+    numberOfDraws = 0;
+    drawTotalTime = 0;
   }
+}
+
+void showSplash()
+{
+  int x0 = (width - QW_BMP_SPARKFUN.width) / 2;
+  if (x0 < 0)
+    x0 = 0;
+
+  int y0 = (height - QW_BMP_SPARKFUN.height) / 2;
+  if (y0 < 0)
+    y0 = 0;
+
+  myOLED.erase();
+  myOLED.bitmap(x0, y0, QW_BMP_SPARKFUN);
+  myOLED.display();
+  delay(2000);
 }

--- a/examples/Example-04_Text/Example-04_Text.ino
+++ b/examples/Example-04_Text/Example-04_Text.ino
@@ -1,74 +1,38 @@
+/*
+  Example-04_Text.ino
 
-// Example-04_Text.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-// Written by Kirk Benell @ SparkFun Electronics, March 2022
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 4 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo shows writing text to an OLED screen using various fonts
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+  This demo shows writing text to an OLED screen using various fonts
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
+QwiicMicroOLED myOLED;
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 // Fonts
 #include <res/qw_fnt_5x7.h>
@@ -77,22 +41,6 @@
 #include <res/qw_fnt_7segment.h>
 #include <res/qw_fnt_largenum.h>
 
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
-QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
-
 // An array of fonts to loop over
 QwiicFont *demoFonts[] = {
     &QW_FONT_5X7,
@@ -100,35 +48,29 @@ QwiicFont *demoFonts[] = {
     &QW_FONT_31X48,
     &QW_FONT_LARGENUM,
     &QW_FONT_7SEGMENT};
-uint8_t nFONTS = sizeof(demoFonts) / sizeof(demoFonts[0]);
-uint8_t iFont = 0;
+int nFONTS = sizeof(demoFonts) / sizeof(demoFonts[0]);
+int iFont = 0;
 
 // Some vars for the title.
-uint8_t xTitle, yTitle;
+int xTitle, yTitle;
 String strTitle = "<<Font>>";
 QwiicFont *pFntTitle = &QW_FONT_5X7;
 
-////////////////////////////////////////////////////////////////////////////////////
-//
 void setup()
 {
-
-    delay(500); // Give display time to power on
     Serial.begin(115200);
+    Serial.println("Running OLED example");
 
-    Serial.println("\n\r-----------------------------------");
-    Serial.print("Example #4 on: ");
-    Serial.println(String(deviceName));
+    Wire.begin();
 
-    if (!myOLED.begin())
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin() == false)
     {
-
-        Serial.println("- Device Begin Failed");
-        while (1)
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
             ;
     }
-
-    Serial.println("- Begin Successful");
+    Serial.println("Begin success");
 
     // Position to use for the time/banner displayed before each font
 
@@ -138,14 +80,26 @@ void setup()
     yTitle = (myOLED.getHeight() - pFntTitle->height) / 2;
 }
 
-////////////////////////////////////////////////////////////////////////////////////
-// writeFontChars()
-//
-// For the current font, write out all it's characters
+void loop()
+{
+    // Write out a title
+    writeTitle();
 
+    delay(1000);
+
+    // next font for display
+    iFont = (iFont + 1) % nFONTS;
+    myOLED.setFont(demoFonts[iFont]);
+
+    // Write out the full font char set
+    writeFontChars();
+
+    delay(2000);
+}
+
+// For the current font, write out all its characters
 void writeFontChars()
 {
-
     // get the font
     QwiicFont *pFont = myOLED.getFont();
 
@@ -175,14 +129,10 @@ void writeFontChars()
         delay(10);
     }
 }
-////////////////////////////////////////////////////////////////////////////////////
-// write_title()
-//
+
 // Simple title for a font
-
-void write_title()
+void writeTitle()
 {
-
     // Set title font font
     myOLED.setFont(pFntTitle);
 
@@ -193,25 +143,4 @@ void write_title()
 
     // There's nothing on the screen yet - Now send the graphics to the device
     myOLED.display();
-}
-
-////////////////////////////////////////////////////////////////////////////////////
-// loop()
-
-void loop()
-{
-
-    // Write out a title
-    write_title();
-
-    delay(1000);
-
-    // next font for display
-    iFont = (iFont + 1) % nFONTS;
-    myOLED.setFont(demoFonts[iFont]);
-
-    // Write out the full font char set
-    writeFontChars();
-
-    delay(2000);
 }

--- a/examples/Example-05_ScrollFlip/Example-05_ScrollFlip.ino
+++ b/examples/Example-05_ScrollFlip/Example-05_ScrollFlip.ino
@@ -1,158 +1,75 @@
-// Example-05_ScrollFlip.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written by Kirk Benell @ SparkFun Electronics, March 2022
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 5 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo shows the various display options - scrolling, flipping, invert.
-//
-// NOTE: Scrolling isn't supported on the Transparent OLED
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+/*
+  Example-05_ScrollFlip.ino
+
+  This demo shows the various display options - scrolling, flipping, invert.
+
+  NOTE: Scrolling isn't supported on the Transparent OLED
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 int yoffset;
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Standard Arduino setup routine
-
-void setup()
-{
-    delay(500); // Give display time to power on
-    Serial.begin(115200);
-
-    Serial.println("\n\r-----------------------------------");
-
-    Serial.print("Running Test #5 on: ");
-    Serial.println(String(deviceName));
-
-    if (!myOLED.begin())
-    {
-
-        Serial.println("- Device Begin Failed");
-        while (1)
-            ;
-    }
-
-    yoffset = (myOLED.getHeight() - myOLED.getFont()->height) / 2;
-
-    delay(1000);
-}
-
 // Our testing functions
-
-void scroll_right(void)
+void scrollRight(void)
 {
-
     myOLED.scrollStop();
     myOLED.scrollRight(0, 7, SCROLL_INTERVAL_2_FRAMES);
 }
 
-void scroll_right_vert(void)
+void scrollRightVertical(void)
 {
     myOLED.scrollStop();
     myOLED.scrollVertRight(0, 7, SCROLL_INTERVAL_3_FRAMES);
 }
 
-void scroll_left(void)
+void scrollLeft(void)
 {
     myOLED.scrollStop();
     myOLED.scrollLeft(0, 7, SCROLL_INTERVAL_4_FRAMES);
 }
 
-void scroll_left_vert(void)
+void scrollLeftVertical(void)
 {
     myOLED.scrollStop();
     myOLED.scrollVertLeft(0, 7, SCROLL_INTERVAL_5_FRAMES);
 }
 
-void scroll_stop(void)
+void scrollStop(void)
 {
     myOLED.scrollStop();
 }
 
-void flip_horz(void)
+void flipHorizontal(void)
 {
-
     for (int i = 0; i < 6; i++)
     {
         myOLED.flipHorizontal(!(i & 0x01));
@@ -160,7 +77,7 @@ void flip_horz(void)
     }
 }
 
-void flip_vert(void)
+void flipVertical(void)
 {
     for (int i = 0; i < 6; i++)
     {
@@ -178,10 +95,7 @@ void invert(void)
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-//
 // Use an array of testing functions, with a title, to run the tests
-
 typedef void (*testFn)(void);
 typedef struct _testRoutines
 {
@@ -190,26 +104,41 @@ typedef struct _testRoutines
 } testRoutine;
 
 static const testRoutine testFunctions[] = {
-    {scroll_right, "Right>"},
-    {scroll_right_vert, "^Right-Up>"},
-    {scroll_left, "<Left"},
-    {scroll_left_vert, "<Left-Up^"},
-    {scroll_stop, "<STOP>"},
-    {flip_horz, "-Flip-Horz-"},
-    {flip_vert, "|Flip-Vert|"},
+    {scrollRight, "Right>"},
+    {scrollRightVertical, "^Right-Up>"},
+    {scrollLeft, "<Left"},
+    {scrollLeftVertical, "<Left-Up^"},
+    {scrollStop, "<STOP>"},
+    {flipHorizontal, "-Flip-Horz-"},
+    {flipVertical, "|Flip-Vert|"},
     {invert, "**INVERT**"}};
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// loop()
-//
-// Standard Arduino loop routine
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println("Running OLED example");
+
+    Wire.begin();
+
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin() == false)
+    {
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
+            ;
+    }
+    Serial.println("Begin success");
+
+    yoffset = (myOLED.getHeight() - myOLED.getFont()->height) / 2;
+
+    delay(1000);
+}
+
 void loop()
 {
-
-    // loop over the test table entries, write title and run test.
-    for (uint8_t i = 0; i < sizeof(testFunctions) / sizeof(testFunctions[0]); i++)
+    // Loop over the test table entries, write title and run test.
+    for (int i = 0; i < sizeof(testFunctions) / sizeof(testFunctions[0]); i++)
     {
-
         if (testFunctions[i].title)
         {
             myOLED.erase();

--- a/examples/Example-06_Clock/Example-06_Clock.ino
+++ b/examples/Example-06_Clock/Example-06_Clock.ino
@@ -1,92 +1,40 @@
+/*
+  Example-06_Clock.ino
 
+  Draws a clock face on the OLED display. This is a port of the demo for the original Micro OLED library.
 
-// Example-06_Clock.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written by
-//      Jim Lindblom @ SparkFun Electronics
-//      Original Creation Date: October 27, 2014
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
 
-// Example 06 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// Draws a clock face on the OLED display. This is a port of the demo for the original Micro OLED library.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by
+      Jim Lindblom @ SparkFun Electronics
+      Original Creation Date: October 27, 2014
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 // Use these variables to set the initial time
 int hours = 11;
@@ -116,26 +64,19 @@ QwiicFont *pFont;
 
 void setup()
 {
-    delay(500); // Give display time to power on
-
-    // Serial on!
     Serial.begin(115200);
+    Serial.println("Running OLED example");
 
-    Serial.println("\n\r-----------------------------------");
-
-    Serial.print("Running Example 01 on: ");
-    Serial.println(String(deviceName));
+    Wire.begin();
 
     // Initalize the OLED device and related graphics system
-    if (!myOLED.begin())
+    if (myOLED.begin() == false)
     {
-
-        Serial.println(" - Device Begin Failed");
-        while (1)
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
             ;
     }
-
-    Serial.println("- Begin Success");
+    Serial.println("Begin success");
 
     pFont = myOLED.getFont();
 
@@ -151,8 +92,8 @@ void loop()
     // Check if we need to update seconds, minutes, hours:
     if (lastDraw + CLOCK_SPEED < millis())
     {
+        lastDraw += CLOCK_SPEED;
 
-        lastDraw = millis();
         // Add a second, update minutes/hours if necessary:
         updateTime();
 

--- a/examples/Example-07_Cube/Example-07_Cube.ino
+++ b/examples/Example-07_Cube/Example-07_Cube.ino
@@ -1,97 +1,46 @@
-// Example-07_Cube.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Written Jim Lindblom @ SparkFun Electronics
-//  Original Creation Date: October 27, 2014
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 7 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo draws a rotating 3D cube
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+/*
+  Example-07_Cube.ino
+
+  This demo draws a rotating 3D cube
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by
+      Jim Lindblom @ SparkFun Electronics
+      Original Creation Date: October 27, 2014
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 int width;
 int height;
 
-uint32_t draw_total_time;
-uint32_t n_draws;
+// For simple frame rate calculations
+long drawTotalTime = 0;
+int numberOfDraws = 0;
 
 float d = 3;
 float px[] = {-d, d, d, -d, -d, d, d, -d};
@@ -107,58 +56,42 @@ float r[3] = {0};
 // This is the number of ms between draws.
 #define ROTATION_SPEED 00
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Standard Arduino setup routine
-
 void setup()
 {
-    delay(500); // Give display time to power on
     Serial.begin(115200);
+    Serial.println("Running OLED example");
 
-    Serial.println("\n\r-----------------------------------");
+    Wire.begin();
+    // Wire.setClock(400000); //Optionally increase I2C bus speed to 400kHz
 
-    Serial.print("Running Test #2 on: ");
-    Serial.println(String(deviceName));
-
-    if (!myOLED.begin())
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin() == false)
     {
-
-        Serial.println("- Device Begin Failed");
-        while (1)
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
             ;
     }
-
-    Serial.println("- Begin Successful");
+    Serial.println("Begin success");
 
     width = myOLED.getWidth();
     height = myOLED.getHeight();
 
-    // for frame rate calc
-    draw_total_time = 0;
-    n_draws = 0;
+    // For frame rate calc
+    drawTotalTime = 0;
+    numberOfDraws = 0;
 
-    // set a template for our framerate display
+    // Set a template for our framerate display
     Serial.print("- Frame Rate: 00.00");
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// loop
-
 void loop()
 {
-    // just draw the cube - as fast as we can!
+    // Draw the cube - as fast as we can!
     drawCube();
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
-// drawCube()
-//
-
 void drawCube()
 {
-
     r[0] = r[0] + PI / 180.0; // Add a degree
     r[1] = r[1] + PI / 180.0; // Add a degree
     r[2] = r[2] + PI / 180.0; // Add a degree
@@ -174,7 +107,6 @@ void drawCube()
 
     for (int i = 0; i < 8; i++)
     {
-
         px2 = px[i];
         py2 = cos(r[0]) * py[i] - sin(r[0]) * pz[i];
         pz2 = sin(r[0]) * py[i] + cos(r[0]) * pz[i];
@@ -191,13 +123,12 @@ void drawCube()
         p2y[i] = height / 2 + ay * SHAPE_SIZE / az;
     }
 
-    // Calculate draw time...
-    uint32_t milStart = millis();
+    // Calculate draw time
+    uint32_t startTime = millis();
 
     myOLED.erase();
     for (int i = 0; i < 3; i++)
     {
-
         myOLED.line(p2x[i], p2y[i], p2x[i + 1], p2y[i + 1]);
         myOLED.line(p2x[i + 4], p2y[i + 4], p2x[i + 5], p2y[i + 5]);
         myOLED.line(p2x[i], p2y[i], p2x[i + 4], p2y[i + 4]);
@@ -209,20 +140,16 @@ void drawCube()
     myOLED.display();
 
     // Write out our frame rate
-    draw_total_time += millis() - milStart;
-    n_draws++;
+    drawTotalTime += millis() - startTime;
+    numberOfDraws++;
 
-    // output framerate?
-    if (n_draws % 120 == 0)
+    // Output framerate once every 120 frames
+    if (numberOfDraws % 120 == 0)
     {
-        // backspace over old number
-        Serial.print("\b\b\b\b\b"); // backspace over old number
-        Serial.print(((float)draw_total_time) / n_draws);
+        Serial.print(" Frame rate: ");
+        Serial.println(numberOfDraws / (float)drawTotalTime * 1000.0);
 
-        if (n_draws > 1000)
-        { // reset after a bit...
-            n_draws = 0;
-            draw_total_time = 0;
-        }
+        numberOfDraws = 0;
+        drawTotalTime = 0;
     }
 }

--- a/examples/Example-08_Multi/Example-08_Multi.ino
+++ b/examples/Example-08_Multi/Example-08_Multi.ino
@@ -1,132 +1,78 @@
-// Example-08_Multi.ino
-//
-// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
-//
-// SparkFun sells these at its website: www.sparkfun.com
-//
-// Do you like this library? Help support SparkFun. Buy a board!
-//
-//   Micro OLED             https://www.sparkfun.com/products/14532
-//   Transparent OLED       https://www.sparkfun.com/products/15173
-//   "Narrow" OLED          https://www.sparkfun.com/products/17153
-//
-//
-// Updated from example writtin by Paul Clark @ SparkFun Electronics
-// Original Creation Date: December 11th, 2020
-//
-// This library configures and draws graphics to OLED boards that use the
-// SSD1306 display hardware. The library only supports I2C.
-//
-// Repository:
-//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
-//
-// Documentation:
-//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
-//
-//
-// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
-//
-// SPDX-License-Identifier: MIT
-//
-//    The MIT License (MIT)
-//
-//    Copyright (c) 2022 SparkFun Electronics
-//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
-//    associated documentation files (the "Software"), to deal in the Software without restriction,
-//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-//    do so, subject to the following conditions:
-//    The above copyright notice and this permission notice shall be included in all copies or substantial
-//    portions of the Software.
-//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
-//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-// Example 8 for the SparkFun Qwiic OLED Arduino Library
-//
-// >> Overview <<
-//
-// This demo performs multiple examples
-//
-//////////////////////////////////////////////////////////////////////////////////////////
-//
-// >>> SELECT THE CONNECTED DEVICE FOR THIS EXAMPLE <<<
-//
+/*
+  Example-08_Multi.ino
+
+  This demo performs multiple examples
+
+  This library configures and draws graphics to OLED boards that use the
+  SSD1306 display hardware. The library only supports I2C.
+
+  SparkFun sells these at its website: www.sparkfun.com
+
+  Do you like this library? Help support SparkFun. Buy a board!
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Updated from example writtin by Paul Clark @ SparkFun Electronics
+  Original Creation Date: December 11th, 2020
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_Graphic_OLED
+
 // The Library supports three different types of SparkFun boards. The demo uses the following
 // defines to determine which device is being used. Uncomment the device being used for this demo.
-//
-// The default is Micro OLED
 
-#define MICRO
-//#define NARROW
-//#define TRANSPARENT
-
-//////////////////////////////////////////////////////////////////////////////////////////
-
-#include <stdint.h>
-
-// Include the SparkFun qwiic OLED Library
-#include <SparkFun_Qwiic_OLED.h>
-
-// What device is being used in this demo
-
-#if defined(TRANSPARENT)
-QwiicTransparentOLED myOLED;
-const char *deviceName = "Transparent OLED";
-
-#elif defined(NARROW)
-QwiicNarrowOLED myOLED;
-const char *deviceName = "Narrow OLED";
-
-#else
 QwiicMicroOLED myOLED;
-const char *deviceName = "Micro OLED";
-
-#endif
+// QwiicTransparentOLED myOLED;
+// QwiicNarrowOLED myOLED;
 
 int width;
 int height;
 
-///////////////////////////////////////////////////////////////////////////////////////////////
-// setup()
-//
-// Standard Arduino setup routine
-
 void setup()
 {
-
-    delay(500); // Give display time to power on
     Serial.begin(115200);
+    Serial.println("Running OLED example");
 
-    Serial.println("\n\r-----------------------------------");
+    Wire.begin();
+    // Wire.setClock(400000); //Optionally increase I2C bus speed to 400kHz
 
-    Serial.print("Running Test #2 on: ");
-    Serial.println(String(deviceName));
-
-    if (!myOLED.begin())
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin() == false)
     {
-
-        Serial.println("- Device Begin Failed");
-        while (1)
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
             ;
     }
-
-    Serial.println("- Begin Successful");
+    Serial.println("Begin success");
 
     width = myOLED.getWidth();
     height = myOLED.getHeight();
 
-    randomSeed(analogRead(A0) + analogRead(A1));
+    // Not all platforms have A0
+#ifdef A0
+    randomSeed(analogRead(A0));
+#endif
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////
-//
+void loop()
+{
+    pixelExample();
+    lineExample();
+    shapeExample();
+}
+
 void pixelExample()
 {
-    // printTitle("Pixels", 1);
     myOLED.erase();
     for (int i = 0; i < 512; i++)
     {
@@ -135,7 +81,6 @@ void pixelExample()
         delay(10);
     }
 }
-///////////////////////////////////////////////////////////////////////////////////////////////
 
 void lineExample()
 {
@@ -144,7 +89,6 @@ void lineExample()
     int xEnd, yEnd;
     int lineWidth = min(middleX, middleY);
 
-    // printTitle("Lines!", 1);
     myOLED.erase();
     int deg;
 
@@ -174,11 +118,9 @@ void lineExample()
         }
     }
 }
-///////////////////////////////////////////////////////////////////////////////////////////////
+
 void shapeExample()
 {
-    // printTitle("Shapes!", 0);
-
     // Silly pong demo. It takes a lot of work to fake pong...
     int paddleW = 3;  // Paddle width
     int paddleH = 15; // Paddle height
@@ -296,12 +238,4 @@ void shapeExample()
     }
     delay(1000);
     myOLED.setDrawMode(grROPCopy);
-}
-///////////////////////////////////////////////////////////////////////////////////////////////
-
-void loop()
-{
-    pixelExample(); // Run the pixel example function
-    lineExample();  // Then the line example function
-    shapeExample(); // Then the shape example
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,63 +6,63 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-QwiicTransparentOLED    KEYWORD1
-QwiicNarrowOLED         KEYWORD1
-QwiicMicroOLED          KEYWORD1
-QwiicFont               KEYWORD1
-grRasterOp_t            KEYWORD1
+QwiicTransparentOLED	KEYWORD1
+QwiicNarrowOLED	KEYWORD1
+QwiicMicroOLED	KEYWORD1
+QwiicFont	KEYWORD1
+grRasterOp_t	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin           KEYWORD2
-getWidth        KEYWORD2
-getHeight       KEYWORD2
-display         KEYWORD2
-erase           KEYWORD2
-invert          KEYWORD2
-scrollRight     KEYWORD2
-scrollLeft      KEYWORD2
-scrollVertRight KEYWORD2
-scrollVertLeft  KEYWORD2
-scrollStop      KEYWORD2
-flipVertical    KEYWORD2
-flipHorizontal  KEYWORD2
-setFont         KEYWORD2
-getFont         KEYWORD2
-setDrawMode     KEYWORD2
-getDrawMode     KEYWORD2
-pixel           KEYWORD2
-line            KEYWORD2
-rectangle       KEYWORD2
-rectangleFill   KEYWORD2
-circle          KEYWORD2
-circleFill      KEYWORD2
-bitmap          KEYWORD2
-text            KEYWORD2
-setCursor       KEYWORD2
-setColor        KEYWORD2
-getColor        KEYWORD2
-write           KEYWORD2
+begin	KEYWORD2
+getWidth	KEYWORD2
+getHeight	KEYWORD2
+display	KEYWORD2
+erase	KEYWORD2
+invert	KEYWORD2
+scrollRight	KEYWORD2
+scrollLeft	KEYWORD2
+scrollVertRight	KEYWORD2
+scrollVertLeft	KEYWORD2
+scrollStop	KEYWORD2
+flipVertical	KEYWORD2
+flipHorizontal	KEYWORD2
+setFont	KEYWORD2
+getFont	KEYWORD2
+setDrawMode	KEYWORD2
+getDrawMode	KEYWORD2
+pixel	KEYWORD2
+line	KEYWORD2
+rectangle	KEYWORD2
+rectangleFill	KEYWORD2
+circle	KEYWORD2
+circleFill	KEYWORD2
+bitmap	KEYWORD2
+text	KEYWORD2
+setCursor	KEYWORD2
+setColor	KEYWORD2
+getColor	KEYWORD2
+write	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-grROPCopy       LITERAL1
-grROPNotCopy    LITERAL1
-grROPNot        LITERAL1
-grROPXOR        LITERAL1
-grROPBlack      LITERAL1
-grROPWhite      LITERAL1
+grROPCopy	LITERAL1
+grROPNotCopy	LITERAL1
+grROPNot	LITERAL1
+grROPXOR	LITERAL1
+grROPBlack	LITERAL1
+grROPWhite	LITERAL1
 
-SCROLL_INTERVAL_5_FRAMES    LITERAL1
-SCROLL_INTERVAL_64_FRAMES   LITERAL1
-SCROLL_INTERVAL_128_FRAMES  LITERAL1
-SCROLL_INTERVAL_256_FRAMES  LITERAL1
-SCROLL_INTERVAL_3_FRAMES    LITERAL1
-SCROLL_INTERVAL_4_FRAMES    LITERAL1
-SCROLL_INTERVAL_25_FRAMES   LITERAL1
-SCROLL_INTERVAL_2_FRAMES    LITERAL1
+SCROLL_INTERVAL_5_FRAMES	LITERAL1
+SCROLL_INTERVAL_64_FRAMES	LITERAL1
+SCROLL_INTERVAL_128_FRAMES	LITERAL1
+SCROLL_INTERVAL_256_FRAMES	LITERAL1
+SCROLL_INTERVAL_3_FRAMES	LITERAL1
+SCROLL_INTERVAL_4_FRAMES	LITERAL1
+SCROLL_INTERVAL_25_FRAMES	LITERAL1
+SCROLL_INTERVAL_2_FRAMES	LITERAL1


### PR DESCRIPTION
* Reformat using default VSC whitespace rules
* Condense example's opening comment blocks
* Simplify early examples as much as possible
* Apply [Arduino API style guide](https://web.archive.org/web/20210217145154/https://www.arduino.cc/en/Reference/APIStyleGuide)
* Fix bug in frame rate math