### PR TITLE
Don't send I2C restart

### DIFF
--- a/src/qwiic_i2c.cpp
+++ b/src/qwiic_i2c.cpp
@@ -145,8 +145,13 @@ int QwI2C::writeRegisterRegion(uint8_t i2c_address, uint8_t offset, uint8_t* dat
         nRemaining -= nToWrite; // Note - use nToWrite, not nSent, or lock on esp32
         data += nSent; // move up to remaining data in buffer
 
+#if defined(ARDUINO_ARCH_ESP32)
+     // if we are on ESP32, release bus no matter what
+     if (m_i2cPort->endTransmission())
+#else
         // only release bus if we've sent all data
-        if (m_i2cPort->endTransmission())
+     if (m_i2cPort->endTransmission(nRemaining <= 0))
+#endif
             return -1; // the client didn't ACK
     }
 

--- a/src/qwiic_i2c.cpp
+++ b/src/qwiic_i2c.cpp
@@ -146,7 +146,7 @@ int QwI2C::writeRegisterRegion(uint8_t i2c_address, uint8_t offset, uint8_t *dat
         data += nSent;          // move up to remaining data in buffer
 
         // only release bus if we've sent all data
-        if(_i2cPort->endTransmission(nRemaining <= 0))
+        if(_i2cPort->endTransmission())
             return -1; // the client didn't ACK
     }
 


### PR DESCRIPTION
### Subject of the issue
Corrupted display, specifically clear is not working.  I have traced to the OLED controller (SSD1306) is not handling the I2C restart bit properly.

### Your workbench
* What version of RTK Surveyor firmware are you running?   RCApr4
* Are you connected to the device over Bluetooth?    No, connected via USB to Config ESP32 port
* What app?    minicomm (terminal emulator)
* Are you transmitting NTRIP back to the device?   No
* How is everything being powered?   Battery / USB
* Are there any additional details that may help us help you?   No

### Steps to reproduce
1. Build the RTK Surveyor firmware with version v1.0.4 of the SparkFun_Qwiic_OLED_Arduino_Library.
2. Upload the firmware to the RTK Express

### Expected behavior
The display should properly display the splash screen and following screens.

### Actual behavior
The screen did not get cleared.  Garbage is being displayed around the edges of the splash screen.
Garbage is displayed around the edges of the main Rover screen.

### The Change
With the restart bit, the OLED controller seems to ignore write data prior to the final restart bit.  A few bits seem to be written and the rest of the display is left with its previous results.  This causes the clear operation which uses the restart bit to fail to clear the display RAM.  Other large writes also fail when the restart bit is sent.

This change removes the use of the I2C restart bit and sends a stop bit instead.  The OLED controller (SSD1306) seems to be remembering where the data should be placed and continues the writing the next data segment to display RAM properly.  As such, the clear operation is broken into sever I2C transfers each bounded by a start and stop bit.  Transmitting the data segments with the start and stop bits causes the OLED controller to properly clear the display RAM.

### Where is the Issue?
Limited testing indicates the is the OLED controller's (SSD1306) handling of the I2C restart bit.  The GNSS library is using the I2C restart bit in communications with the GPS.  Removing the use of the restart bit for that library, causes the GNSS library to fail all communications with the GPS.  As such, the ESP32 must be sending the restart bit successfully and the GPS must be receiving it successfully and processing it accordingly.

### What can break?
If the ESP32 is being used in a multi-master design, then not using the restart allows another bus master to potentially slip something between the two segments of the transfer.  This would delay the transmission of the next segment of data.  If two or more masters were writing to the OLED display then not using the restart opens up a window where another master could send a command to the SSD1306 and change the current column or page.  This would cause the subsequent portion of data to be placed in the wrong location and possibly write past the end of display memory.

As long as a single master is on the I2C bus, I2C timing changes slightly due to the addition of the stop bit, but no other impact to the devices in the I2C bus should be seen.