### PR TITLE
Added #include <avr/pgmspace.h>

### DIFF
--- a/src/qwiic_grbuffer.cpp
+++ b/src/qwiic_grbuffer.cpp
@@ -66,6 +66,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <avr/pgmspace.h>
 
 // default font
 #include "res/qw_fnt_5x7.h"


### PR DESCRIPTION
Without this the examples did not compile either using Arduino IDE 2.0 or VSCode with platformIO with Arduino Nano 33 BLE