### PR TITLE
Add QwiicCustomOLED

### DIFF
--- a/examples/Example-09_CustomOLED/Example-09_CustomOLED.ino
+++ b/examples/Example-09_CustomOLED/Example-09_CustomOLED.ino
@@ -1,0 +1,89 @@
+/*
+
+  Example-09_CustomOLED.ino
+
+  This demo shows the basic setup of the OLED library, generating simple graphics and displaying
+  the results on the target device.
+
+   Micro OLED             https://www.sparkfun.com/products/14532
+   Transparent OLED       https://www.sparkfun.com/products/15173
+   "Narrow" OLED          https://www.sparkfun.com/products/17153
+
+  Written by Kirk Benell @ SparkFun Electronics, March 2022
+
+  Repository:
+     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+
+  Documentation:
+     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+
+  SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+*/
+
+#include <SparkFun_Qwiic_OLED.h> //http://librarymanager/All#SparkFun_Qwiic_OLED
+
+
+// This demo shows how to use the QwiicCustomOLED class,
+// allowing the display width, height etc. to be set manually.
+
+QwiicCustomOLED myOLED;
+
+
+void setup()
+{
+    delay(1000);
+    
+    Serial.begin(115200);
+    Serial.println("Running OLED example");
+
+    Wire.begin();
+
+    // If desired, we can customize the OLED before we begin it.
+    // Otherwise it will default to 128x64 (1.3" OLED).
+    myOLED.m_device.xOffset = 0; // Set the active area X offset. For the Micro 64x48, set this to 2
+    myOLED.m_device.yOffset = 0; // Set the active area Y offset
+    myOLED.m_device.displayWidth = 128; // Set the active area width
+    myOLED.m_device.displayHeight = 64; // Set the active area height
+    myOLED.m_device.pinConfig = 0x12; // Set COM Pins Hardware Configuration (DAh)
+    myOLED.m_device.preCharge = 0xF1; // Set Pre-charge Period (D9h)
+    myOLED.m_device.vcomDeselect = 0x40; // Set VCOMH Deselect Level (DBh)
+    myOLED.m_device.contrast = 0xCF; // Set Contrast Control for BANK0 (81h)
+
+    // Initalize the OLED device and related graphics system
+    if (myOLED.begin(Wire, 0x3D) == false) // The TwoWire port and I2C address are set here
+    {
+        Serial.println("Device begin failed. Freezing...");
+        while (true)
+            ;
+    }
+    Serial.println("Begin success");
+
+    // Do a simple test - fill a rectangle on the screen and then print hello!
+
+    // Fill a rectangle on the screen that has a 4 pixel board
+    myOLED.rectangleFill(4, 4, myOLED.getWidth() - 8, myOLED.getHeight() - 8);
+
+    String hello = "hello"; // our message
+
+    // Center our message on the screen. Get the screen size of the "hello" string,
+    // calling the getStringWidth() and getStringHeight() methods on the oled
+
+    // starting x position - screen width minus string width  / 2
+    int x0 = (myOLED.getWidth() - myOLED.getStringWidth(hello)) / 2;
+
+    // starting y position - screen height minus string height / 2 
+    int y0 = (myOLED.getHeight() - myOLED.getStringHeight(hello)) / 2;
+
+    // Draw the text - color of black (0)
+    myOLED.text(x0, y0, hello, 0);
+
+    // There's nothing on the screen yet - Now send the graphics to the device
+    myOLED.display();
+
+    // That's it - HELLO!
+}
+
+void loop()
+{
+    delay(1000); // Do nothing
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -10,6 +10,7 @@ QwiicTransparentOLED	KEYWORD1
 QwiicNarrowOLED	KEYWORD1
 QwiicMicroOLED	KEYWORD1
 Qwiic1in3OLED	KEYWORD1
+QwiicCustomOLED	KEYWORD1
 QwiicFont	KEYWORD1
 grRasterOp_t	KEYWORD1
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic OLED Arduino Library
-version=1.0.8
+version=1.0.9
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for SparkFun SSD1306 based OLED display products.

--- a/src/SparkFun_Qwiic_OLED.h
+++ b/src/SparkFun_Qwiic_OLED.h
@@ -53,6 +53,7 @@
 #include "qwiic_olednarrow.h"
 #include "qwiic_oledtransp.h"
 #include "qwiic_oled_1in3.h"
+#include "qwiic_oled_custom.h"
 
 #include <Arduino.h>
 #include <Wire.h>
@@ -84,9 +85,10 @@ typedef QwBitmap QwiicBitmap;
 
 template <typename SSD1306DeviceType>
 class QwiicOLEDBaseClass : public Print { // NOTE: implementing Arduino Print
-private:
+public:
     // our device driver
     SSD1306DeviceType m_device;
+private:
     QwI2C m_i2cBus; // our i2c object
 
     // for the Aruduino print functionaliyt
@@ -834,5 +836,9 @@ class QwiicTransparentOLED : public QwiicOLEDBaseClass<QwOLEDTransparent> {
 };
 
 class Qwiic1in3OLED : public QwiicOLEDBaseClass<QwOLED1in3> {
+    // nothing here - see above
+};
+
+class QwiicCustomOLED : public QwiicOLEDBaseClass<QwOLEDCustom> {
     // nothing here - see above
 };

--- a/src/qwiic_oled_custom.h
+++ b/src/qwiic_oled_custom.h
@@ -1,0 +1,113 @@
+// qwiic_oled_custom.h
+//
+// This is a library written for SparkFun Qwiic OLED boards that use the SSD1306.
+//
+// SparkFun sells these at its website: www.sparkfun.com
+//
+// Do you like this library? Help support SparkFun. Buy a board!
+//
+//   Micro OLED             https://www.sparkfun.com/products/14532
+//   Transparent OLED       https://www.sparkfun.com/products/15173
+//   "Narrow" OLED          https://www.sparkfun.com/products/17153
+//   1.3" OLED              https://www.sparkfun.com/products/23453
+//
+//
+// Written by Kirk Benell @ SparkFun Electronics, March 2022
+//
+// This library configures and draws graphics to OLED boards that use the
+// SSD1306 display hardware. The library only supports I2C.
+//
+// Repository:
+//     https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library
+//
+// Documentation:
+//     https://sparkfun.github.io/SparkFun_Qwiic_OLED_Arduino_Library/
+//
+//
+// SparkFun code, firmware, and software is released under the MIT License(http://opensource.org/licenses/MIT).
+//
+// SPDX-License-Identifier: MIT
+//
+//    The MIT License (MIT)
+//
+//    Copyright (c) 2022 SparkFun Electronics
+//    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+//    associated documentation files (the "Software"), to deal in the Software without restriction,
+//    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//    and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
+//    do so, subject to the following conditions:
+//    The above copyright notice and this permission notice shall be included in all copies or substantial
+//    portions of the Software.
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//    NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Implementation for the 1.3" OLED device
+
+#pragma once
+
+#include "qwiic_grssd1306.h"
+
+//////////////////////////////////////////////////////////////////
+// Set the defaults for the SparkFun Qwiic MicroOLED
+
+#define kOLEDCustomDefaultWidth 128
+#define kOLEDCustomDefaultHeight 64
+
+#define kOLEDCustomDefaultXOffset 0
+#define kOLEDCustomDefaultYOffset 0
+
+// Parameters for this device
+#define kOLEDCustomDefaultPinConfig 0x12
+#define kOLEDCustomDefaultPreCharge 0xF1
+#define kOLEDCustomDefaultVCOM 0x40
+#define kOLEDCustomDefaultContrast 0xCF
+
+#define kOLEDCustomDefaultDefaultAddress 0x3D
+#define kOLEDCustomDefaultAltAddress 0x3C
+
+class QwOLEDCustom : public QwGrSSD1306 {
+
+public:
+    // Constructor - setup the viewport and default address for this device.
+    QwOLEDCustom()
+        : QwGrSSD1306(kOLEDCustomDefaultXOffset, kOLEDCustomDefaultYOffset, kOLEDCustomDefaultWidth, kOLEDCustomDefaultHeight)
+    {
+        default_address = kOLEDCustomDefaultDefaultAddress;
+    };
+
+    ~QwOLEDCustom(){if (m_graphicsBuffer != nullptr) delete m_graphicsBuffer;};
+
+    // set up the specific device settings
+    bool init(void)
+    {
+        setViewport(xOffset, yOffset, displayWidth, displayHeight);
+
+        setCommPins(pinConfig);
+        setPreCharge(preCharge);
+        setVcomDeselect(vcomDeselect);
+        setContrast(contrast);
+
+        if (m_graphicsBuffer == nullptr)
+            m_graphicsBuffer = new uint8_t[(uint16_t)displayWidth * (uint16_t)displayHeight / 8];
+        setBuffer(m_graphicsBuffer); // The buffer to use
+
+        // Call the super class to do all the work
+        return this->QwGrSSD1306::init();
+    };
+
+    uint8_t xOffset = kOLEDCustomDefaultXOffset;
+    uint8_t yOffset = kOLEDCustomDefaultYOffset;
+    uint8_t displayWidth = kOLEDCustomDefaultWidth;
+    uint8_t displayHeight = kOLEDCustomDefaultHeight;
+    uint8_t pinConfig =  kOLEDCustomDefaultPinConfig;
+    uint8_t preCharge = kOLEDCustomDefaultPreCharge;
+    uint8_t vcomDeselect = kOLEDCustomDefaultVCOM;
+    uint8_t contrast = kOLEDCustomDefaultContrast;
+
+protected:
+    // Graphics buffer for this device.
+    uint8_t *m_graphicsBuffer = nullptr;
+};

--- a/src/qwiic_oled_custom.h
+++ b/src/qwiic_oled_custom.h
@@ -78,7 +78,11 @@ public:
         default_address = kOLEDCustomDefaultDefaultAddress;
     };
 
-    ~QwOLEDCustom(){if (m_graphicsBuffer != nullptr) delete m_graphicsBuffer;};
+    ~QwOLEDCustom()
+    {
+        if (m_graphicsBuffer != nullptr)
+            delete[] m_graphicsBuffer;
+    };
 
     // set up the specific device settings
     bool init(void)
@@ -90,8 +94,9 @@ public:
         setVcomDeselect(vcomDeselect);
         setContrast(contrast);
 
-        if (m_graphicsBuffer == nullptr)
-            m_graphicsBuffer = new uint8_t[(uint16_t)displayWidth * (uint16_t)displayHeight / 8];
+        if (m_graphicsBuffer != nullptr)
+            delete[] m_graphicsBuffer;
+        m_graphicsBuffer = new uint8_t[(uint16_t)displayWidth * (uint16_t)displayHeight / 8];
         setBuffer(m_graphicsBuffer); // The buffer to use
 
         // Call the super class to do all the work


### PR DESCRIPTION
This release adds the ```QwiicCustomOLED``` class:
* The display width, height, contrast etc. can be defined manually before the display is begun
* This allows a single class to be used for multiple display types
  * This is useful when writing code for a product which could have either a 64x48 Micro OLED or a 128x64 1.3" OLED connected