### PR TITLE
Fix issue with drawing bitmaps of certain heights at non-zero y0 values

### DIFF
--- a/src/qwiic_grssd1306.cpp
+++ b/src/qwiic_grssd1306.cpp
@@ -880,7 +880,7 @@ void QwGrSSD1306::drawBitmap(uint8_t x0, uint8_t y0, uint8_t dst_width,
 
             if (remainingBits) // more data to add from the next byte in this column
                 bmp_data |= (pBitmap[bmp_width * (bmpPage + 1) + bmp_x] & bmp_mask[1])
-                    << (kByteNBits - remainingBits);
+                    << (neededBits - remainingBits);
 
             // Write the bmp data to the graphics buffer - using current write op.
             // Note, if the location in the buffer didn't start at bit 0, we shift


### PR DESCRIPTION
There was a minor logic error within [QwGrSSD1306::drawBitmap](https://github.com/sparkfun/SparkFun_Qwiic_OLED_Arduino_Library/blob/main/src/qwiic_grssd1306.cpp#L788) function which caused bitmaps of some heights to drop pixel rows. This was due to an incorrect left-shift value when `remainingBits` was greater than 0.  

To resolve, we derive the left-shift value using:
```cpp
(neededBits - remainingBits)
```
rather than:
```cpp
(kByteNBits - remainingBits)
```

This handles scenarios where there is less than one bytes worth of bitmap data remaining past the "straddle point"

Resolves #17 