### PR TITLE
Fix heap corruption caused by specifying an x value outside of display

### DIFF
--- a/src/qwiic_grssd1306.cpp
+++ b/src/qwiic_grssd1306.cpp
@@ -130,6 +130,8 @@
     } while (false)
 
 // Macro to check and adjust record bounds based on a single location
+// The _x_ value must be within the screen (0 <= x < width), limit
+// values are ignored
 #define pageCheckBounds(_page_, _x_)                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -140,6 +142,8 @@
     } while (false)
 
 // Macro to check and adjust record bounds using another page descriptor
+// The _page2_ x values must be within the screen (0 <= x < width), limit
+// values are ignored
 #define pageCheckBoundsDesc(_page_, _page2_)                                                                           \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -150,6 +154,7 @@
     } while (false)
 
 // Macro to check and adjust record bounds using bounds values
+// Values _x0_ and _x1_ must be within the screen (0 <= x < width)
 #define pageCheckBoundsRange(_page_, _x0_, _x1_)                                                                       \
     do                                                                                                                 \
     {                                                                                                                  \
@@ -880,7 +885,7 @@ void QwGrSSD1306::drawBitmap(uint8_t x0, uint8_t y0, uint8_t dst_width, uint8_t 
         bmp_y += neededBits;
 
         pageCheckBoundsRange(m_pageState[iPage], x0,
-                             x0 + dst_width); // mark dirty range in page desc
+                             x0 + dst_width - 1); // mark dirty range in page desc
     }
 }
 


### PR DESCRIPTION
Bug:
The memory corruption occurs during the memset call in the erase routine.  When bad values are in drawBitmap the number of bytes to zero is too long by 1 byte.  These values are updated by several macros, one of which is pageCheckBoundsRange.  The values passed to this macro should be x values that match physical pixels on the screen.  However calls to drawBitmap was using the number of screen pixels or width to offset the current x value resulting in the next pixel (not updated) instead of the last pixel (updated).  When the bitmap or a portion of the bitmap is at the edge of the screen, this results in an invalid x value outside the range of (0 <= x < width).

Fix:
* Compute the last updated pixel offset for the pageCheckBoundsRange in drawBitmap
* Add comments to pageCheckBounds* macros to specify bounds in hopes of avoiding a similar issue in the future